### PR TITLE
Fix a 404 bug when bound function is called in RESTier TripPin Sample.

### DIFF
--- a/RESTier/Trippin/Trippin/Web.config
+++ b/RESTier/Trippin/Trippin/Web.config
@@ -67,10 +67,10 @@
   </connectionStrings>
   <system.webServer>
     <handlers>
-      
-      
-      
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
+      <remove name="OPTIONSVerbHandler" />
+      <remove name="TRACEVerbHandler" />
       <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*" verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
-    <remove name="ExtensionlessUrlHandler-Integrated-4.0" /><remove name="OPTIONSVerbHandler" /><remove name="TRACEVerbHandler" /><add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" /></handlers>
+    </handlers>
   </system.webServer>
 </configuration>


### PR DESCRIPTION
change the path in ExtensionlessUrlHandler-Integrated-4.0 handler from . to be *, it fix a 404 error when bound function is called.