### PR TITLE
ODataFunctionSample for 7.x classic and AspNetCore

### DIFF
--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNet/App.config
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNet/App.config
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.OData.Core" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.5.0.20627" newVersion="7.5.0.20627"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.OData.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.5.0.20627" newVersion="7.5.0.20627"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.5.0.20627" newVersion="7.5.0.20627"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNet/Controllers/ProductsController.cs
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNet/Controllers/ProductsController.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Web.Http;
+
+using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Routing;
+
+using ODataFunctionSample.Models;
+
+namespace ODataFunctionSample.AspNet.Controllers
+{
+    public class ProductsController : ODataController
+    {
+        private static ConcurrentDictionary<int, Product> _data;
+
+        static ProductsController()
+        {
+            _data = new ConcurrentDictionary<int, Product>();
+            var rand = new Random();
+
+            Enumerable.Range(0, 100)
+                .Select(i => new Product
+                {
+                    Id = i,
+                    Name = "Product " + i,
+                    Price = rand.NextDouble() * 1000
+                })
+                .ToList()
+                .ForEach(p => _data.TryAdd(p.Id, p));
+        }
+
+        public ProductsController()
+        {
+        }
+
+        [EnableQuery]
+        public IQueryable<Product> Get()
+        {
+            return _data.Values.AsQueryable();
+        }
+
+        public IHttpActionResult GetProduct(int key)
+        {
+            Product retval;
+            if (_data.TryGetValue(key, out retval))
+            {
+                return Ok(retval);
+            }
+            else
+            {
+                return NotFound();
+            }
+        }
+
+        [HttpGet]
+        public IHttpActionResult MostExpensive()
+        {
+            var retval = _data.Max(pair => pair.Value.Price);
+
+            return Ok(retval);
+        }
+
+        // Returns the top ten most expensive products
+        [HttpGet]
+        public IHttpActionResult Top10()
+        {
+            var retval = _data.Values.OrderByDescending(p => p.Price).Take(10).ToList();
+
+            return Ok(retval);
+        }
+
+        [HttpGet]
+        public IHttpActionResult GetPriceRank(int key)
+        {
+            Product p;
+            if (_data.TryGetValue(key, out p))
+            {
+                // NOTE: Use where clause to get the rank of the price may not
+                // offer the good time complexity. The following code is intended
+                // for demonstration only.
+                return Ok(_data.Values.Where(one => one.Price > p.Price).Count());
+            }
+            else
+            {
+                return NotFound();
+            }
+        }
+
+        [HttpGet]
+        public IHttpActionResult CalculateGeneralSalesTax(int key, string state)
+        {
+            double taxRate = GetRate(state);
+
+            Product product;
+            if (_data.TryGetValue(key, out product))
+            {
+                double tax = product.Price * taxRate / 100;
+                return Ok(tax);
+            }
+            else
+            {
+                return NotFound();
+            }
+        }
+
+        [HttpGet]
+        [ODataRoute("GetSalesTaxRate(state={state})")]
+        public IHttpActionResult GetSalesTaxRate([FromODataUri] string state)
+        {
+            return Ok(GetRate(state));
+        }
+
+        private static double GetRate(string state)
+        {
+            double taxRate = 0;
+            switch (state)
+            {
+                case "AZ": taxRate = 5.6; break;
+                case "CA": taxRate = 7.5; break;
+                case "CT": taxRate = 6.35; break;
+                case "GA": taxRate = 4; break;
+                case "IN": taxRate = 7; break;
+                case "KS": taxRate = 6.15; break;
+                case "KY": taxRate = 6; break;
+                case "MA": taxRate = 6.25; break;
+                case "NV": taxRate = 6.85; break;
+                case "NJ": taxRate = 7; break;
+                case "NY": taxRate = 4; break;
+                case "NC": taxRate = 4.75; break;
+                case "ND": taxRate = 5; break;
+                case "PA": taxRate = 6; break;
+                case "TN": taxRate = 7; break;
+                case "TX": taxRate = 6.25; break;
+                case "VA": taxRate = 4.3; break;
+                case "WA": taxRate = 6.5; break;
+                case "WV": taxRate = 6; break;
+                case "WI": taxRate = 5; break;
+
+                default:
+                    taxRate = 0;
+                    break;
+            }
+
+            return taxRate;
+        }
+    }
+}

--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNet/ODataFunctionSample.AspNet.csproj
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNet/ODataFunctionSample.AspNet.csproj
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1D794E9C-BAA2-4E69-8268-1A879B020CB5}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>FunctionSample</RootNamespace>
+    <AssemblyName>FunctionSample</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.AspNet.OData, Version=7.0.1.20718, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.OData.7.0.1\lib\net45\Microsoft.AspNet.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.1.0.0\lib\netstandard1.1\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.1.0.0\lib\netstandard1.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.OData.Core, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OData.Core.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.OData.Edm, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OData.Edm.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Hosting, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Spatial, Version=7.5.0.20627, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Spatial.7.5.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Web.Http.Owin, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Owin.5.2.3\lib\net45\System.Web.Http.Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Controllers\ProductsController.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Startup.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <Import Project="..\ODataFunctionSample.Models\ODataFunctionSample.Models.projitems" Label="Shared" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNet/Program.cs
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNet/Program.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Owin.Hosting;
+
+namespace ODataFunctionSample.AspNet
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            const string baseAddress = "http://localhost:9010/";
+            var client = new HttpClient();
+
+            using (WebApp.Start<Startup>(url: baseAddress))
+            {
+                Comment("Service is listening to " + baseAddress);
+
+                Comment("List all the products.");
+
+                Comment(client.GetAsync(baseAddress + "odata/Products").Result.Content.ReadAsStringAsync().Result);
+                Comment();
+
+                // Sample 1: return a value from a function bound to a collection
+                ExecuteSample("Sample 1: Get the most expensive product.",
+                    baseAddress + "odata/Products/Default.MostExpensive()").Wait(1000);
+                // Sample 2: return a collection from a function bound to a collection
+                ExecuteSample("Sample 2: Get the top 10 expensive product.",
+                    baseAddress + "odata/Products/Default.Top10()").Wait(1000);
+                // Sample 3: return a value from a function bound to an entity
+                ExecuteSample("Sample 3: Get the rank of the product price.",
+                    baseAddress + "odata/Products(33)/Default.GetPriceRank()").Wait(1000);
+                // Sample 4: return a value from a function which accepts a parameter
+                ExecuteSample("Sample 4: Get the sales tax.",
+                    baseAddress + "odata/Products(33)/Default.CalculateGeneralSalesTax(state='WA')").Wait(1000);
+                // Sample 5: return a value from a services level function
+                ExecuteSample("Sample 5: Get the sales tax rate.",
+                    baseAddress + "odata/GetSalesTaxRate(state='CA')").Wait(1000);
+                //Sample 6: call function with parameter alias
+                ExecuteSample("Sample 6: call function with parameter alias.",
+                    baseAddress + "odata/GetSalesTaxRate(state=@p1)?@p1='ND'").Wait(1000);
+
+                Comment("Press and key to exit.");
+                Console.ReadKey();
+            }
+        }
+
+        private static async Task ExecuteSample(string caseName, string url)
+        {
+            Comment(caseName);
+
+            Comment("GET " + url);
+            Comment();
+
+            var client = new HttpClient();
+            var response = await client.GetAsync(url);
+            var content = await response.Content.ReadAsStringAsync();
+
+            Comment(response.ToString());
+            Comment(content);
+            Comment();
+        }
+
+        public static void Comment()
+        {
+            Console.WriteLine();
+        }
+
+        public static void Comment(string message)
+        {
+            Console.WriteLine(message);
+        }
+    }
+}

--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNet/Properties/AssemblyInfo.cs
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNet/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("FunctionSample")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("FunctionSample")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("062ced55-752d-47f4-9c9b-cbed9e405f44")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNet/Startup.cs
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNet/Startup.cs
@@ -1,0 +1,62 @@
+﻿using System.Web.Http;
+using ODataFunctionSample.Models;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.OData.Edm;
+using Owin;
+
+namespace ODataFunctionSample.AspNet
+{
+    public class Startup
+    {
+        public void Configuration(IAppBuilder builder)
+        {
+            var config = new HttpConfiguration();
+            config.MapODataServiceRoute(routeName: "odata route", routePrefix: "odata", model: GetEdmMode());
+            builder.UseWebApi(config);
+        }
+
+        private IEdmModel GetEdmMode()
+        {
+            ODataModelBuilder builder = new ODataConventionModelBuilder();
+
+            builder.EntitySet<Product>("Products");
+
+            var productType = builder.EntityType<Product>();
+
+            // Function bound to a collection
+            // Returns the most expensive product, a single entity
+            productType.Collection
+                .Function("MostExpensive")
+                .Returns<double>();
+
+            // Function bound to a collection
+            // Returns the top 10 product, a collection
+            productType.Collection
+                .Function("Top10")
+                .ReturnsCollectionFromEntitySet<Product>("Products");
+
+            // Function bound to a single entity
+            // Returns the instance's price rank among all products
+            productType
+                .Function("GetPriceRank")
+                .Returns<int>();
+
+            // Function bound to a single entity
+            // Accept a string as parameter and return a double
+            // This function calculate the general sales tax base on the 
+            // state
+            productType
+                .Function("CalculateGeneralSalesTax")
+                .Returns<double>()
+                .Parameter<string>("state");
+
+            // Unbound Function
+            builder.Function("GetSalesTaxRate")
+                .Returns<double>()
+                .Parameter<string>("state");
+
+            return builder.GetEdmModel();
+        }
+    }
+}

--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNet/packages.config
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNet/packages.config
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.OData" version="7.0.1" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Core" version="7.5.0" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.5.0" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.5.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Owin" version="1.0" targetFramework="net45" />
+  <package id="System.Collections" version="4.0.11" targetFramework="net45" />
+  <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net45" />
+  <package id="System.ComponentModel" version="4.0.1" targetFramework="net45" />
+  <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net45" />
+  <package id="System.Globalization" version="4.0.11" targetFramework="net45" />
+  <package id="System.Linq" version="4.1.0" targetFramework="net45" />
+  <package id="System.Linq.Expressions" version="4.1.0" targetFramework="net45" />
+  <package id="System.Reflection" version="4.1.0" targetFramework="net45" />
+  <package id="System.Resources.ResourceManager" version="4.0.1" targetFramework="net45" />
+  <package id="System.Runtime.Extensions" version="4.1.0" targetFramework="net45" />
+  <package id="System.Threading" version="4.0.11" targetFramework="net45" />
+  <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net45" />
+</packages>

--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNetCore/Controllers/ProductsController.cs
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNetCore/Controllers/ProductsController.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+
+using Microsoft.AspNet.OData;
+using Microsoft.AspNet.OData.Routing;
+using Microsoft.AspNetCore.Mvc;
+
+using ODataFunctionSample.Models;
+
+namespace ODataFunctionSample.AspNetCore.Controllers
+{
+    public class ProductsController : ODataController
+    {
+        private static ConcurrentDictionary<int, Product> _data;
+
+        static ProductsController()
+        {
+            _data = new ConcurrentDictionary<int, Product>();
+            var rand = new Random();
+
+            Enumerable.Range(0, 100)
+                .Select(i => new Product
+                {
+                    Id = i,
+                    Name = "Product " + i,
+                    Price = rand.NextDouble() * 1000
+                })
+                .ToList()
+                .ForEach(p => _data.TryAdd(p.Id, p));
+        }
+
+        public ProductsController()
+        {
+        }
+
+        [EnableQuery]
+        public IQueryable<Product> Get()
+        {
+            return _data.Values.AsQueryable();
+        }
+
+        public IActionResult GetProduct(int key)
+        {
+            Product retval;
+            if (_data.TryGetValue(key, out retval))
+            {
+                return Ok(retval);
+            }
+            else
+            {
+                return NotFound();
+            }
+        }
+
+        [HttpGet]
+        public IActionResult MostExpensive()
+        {
+            var retval = _data.Max(pair => pair.Value.Price);
+
+            return Ok(retval);
+        }
+
+        // Returns the top ten most expensive products
+        [HttpGet]
+        public IActionResult Top10()
+        {
+            var retval = _data.Values.OrderByDescending(p => p.Price).Take(10).ToList();
+
+            return Ok(retval);
+        }
+
+        [HttpGet]
+        public IActionResult GetPriceRank(int key)
+        {
+            Product p;
+            if (_data.TryGetValue(key, out p))
+            {
+                // NOTE: Use where clause to get the rank of the price may not
+                // offer the good time complexity. The following code is intended
+                // for demonstration only.
+                return Ok(_data.Values.Where(one => one.Price > p.Price).Count());
+            }
+            else
+            {
+                return NotFound();
+            }
+        }
+
+        [HttpGet]
+        public IActionResult CalculateGeneralSalesTax(int key, string state)
+        {
+            double taxRate = GetRate(state);
+
+            Product product;
+            if (_data.TryGetValue(key, out product))
+            {
+                double tax = product.Price * taxRate / 100;
+                return Ok(tax);
+            }
+            else
+            {
+                return NotFound();
+            }
+        }
+
+        [HttpGet]
+        [ODataRoute("GetSalesTaxRate(state={state})")]
+        public IActionResult GetSalesTaxRate([FromODataUri] string state)
+        {
+            return Ok(GetRate(state));
+        }
+
+        private static double GetRate(string state)
+        {
+            double taxRate = 0;
+            switch (state)
+            {
+                case "AZ": taxRate = 5.6; break;
+                case "CA": taxRate = 7.5; break;
+                case "CT": taxRate = 6.35; break;
+                case "GA": taxRate = 4; break;
+                case "IN": taxRate = 7; break;
+                case "KS": taxRate = 6.15; break;
+                case "KY": taxRate = 6; break;
+                case "MA": taxRate = 6.25; break;
+                case "NV": taxRate = 6.85; break;
+                case "NJ": taxRate = 7; break;
+                case "NY": taxRate = 4; break;
+                case "NC": taxRate = 4.75; break;
+                case "ND": taxRate = 5; break;
+                case "PA": taxRate = 6; break;
+                case "TN": taxRate = 7; break;
+                case "TX": taxRate = 6.25; break;
+                case "VA": taxRate = 4.3; break;
+                case "WA": taxRate = 6.5; break;
+                case "WV": taxRate = 6; break;
+                case "WI": taxRate = 5; break;
+
+                default:
+                    taxRate = 0;
+                    break;
+            }
+
+            return taxRate;
+        }
+    }
+}

--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNetCore/ODataFunctionSample.AspNetCore.csproj
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNetCore/ODataFunctionSample.AspNetCore.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Remove="wwwroot\**" />
+    <Content Remove="wwwroot\**" />
+    <EmbeddedResource Remove="wwwroot\**" />
+    <None Remove="wwwroot\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.0.1" />
+  </ItemGroup>
+
+  <Import Project="..\ODataFunctionSample.Models\ODataFunctionSample.Models.projitems" Label="Shared" />
+
+</Project>

--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNetCore/Program.cs
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNetCore/Program.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace ODataFunctionSample.AspNetCore
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>();
+    }
+}

--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNetCore/Properties/launchSettings.json
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNetCore/Properties/launchSettings.json
@@ -1,0 +1,30 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:33975",
+      "sslPort": 44363
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "odata/Products/Default.Top10()",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "ODataFunctionSample.AspNetCore": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "odata/Products/Default.Top10()",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNetCore/Startup.cs
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNetCore/Startup.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ODataFunctionSample.Models;
+using Microsoft.AspNet.OData.Builder;
+using Microsoft.AspNet.OData.Extensions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpsPolicy;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.OData.Edm;
+
+namespace ODataFunctionSample.AspNetCore
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddOData();
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            else
+            {
+                app.UseHsts();
+            }
+
+            app.UseDefaultFiles();
+            app.UseStaticFiles();
+
+            app.UseHttpsRedirection();
+            app.UseMvc(appBuilder =>
+            {
+                appBuilder.MapODataServiceRoute("odata", "odata", GetEdmModel());
+            });
+        }
+
+        // Builds the EDM model for the OData service, including the OData action definitions.
+        private static IEdmModel GetEdmModel()
+        {
+            ODataModelBuilder builder = new ODataConventionModelBuilder();
+
+            builder.EntitySet<Product>("Products");
+
+            var productType = builder.EntityType<Product>();
+
+            // Function bound to a collection
+            // Returns the most expensive product, a single entity
+            productType.Collection
+                .Function("MostExpensive")
+                .Returns<double>();
+
+            // Function bound to a collection
+            // Returns the top 10 product, a collection
+            productType.Collection
+                .Function("Top10")
+                .ReturnsCollectionFromEntitySet<Product>("Products");
+
+            // Function bound to a single entity
+            // Returns the instance's price rank among all products
+            productType
+                .Function("GetPriceRank")
+                .Returns<int>();
+
+            // Function bound to a single entity
+            // Accept a string as parameter and return a double
+            // This function calculate the general sales tax base on the
+            // state
+            productType
+                .Function("CalculateGeneralSalesTax")
+                .Returns<double>()
+                .Parameter<string>("state");
+
+            // Unbound Function
+            builder.Function("GetSalesTaxRate")
+                .Returns<double>()
+                .Parameter<string>("state");
+
+            return builder.GetEdmModel();
+        }
+    }
+}

--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNetCore/appsettings.Development.json
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNetCore/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  }
+}

--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNetCore/appsettings.json
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.AspNetCore/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.Models/Models/Product.cs
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.Models/Models/Product.cs
@@ -1,0 +1,11 @@
+﻿namespace ODataFunctionSample.Models
+{
+    public class Product
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        public double Price { get; set; }
+    }
+}

--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.Models/ODataFunctionSample.Models.projitems
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.Models/ODataFunctionSample.Models.projitems
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>c4e021b8-16cd-4c82-90cd-7201a4ad6b00</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>ODataFunctionSample.Models</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Models\Product.cs" />
+  </ItemGroup>
+</Project>

--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.Models/ODataFunctionSample.Models.shproj
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.Models/ODataFunctionSample.Models.shproj
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>c4e021b8-16cd-4c82-90cd-7201a4ad6b00</ProjectGuid>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="ODataFunctionSample.Models.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.sln
+++ b/WebApi/v7.x/ODataFunctionSample/ODataFunctionSample.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2026
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ODataFunctionSample.AspNet", "ODataFunctionSample.AspNet\ODataFunctionSample.AspNet.csproj", "{1D794E9C-BAA2-4E69-8268-1A879B020CB5}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "ODataFunctionSample.Models", "ODataFunctionSample.Models\ODataFunctionSample.Models.shproj", "{C4E021B8-16CD-4C82-90CD-7201A4AD6B00}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ODataFunctionSample.AspNetCore", "ODataFunctionSample.AspNetCore\ODataFunctionSample.AspNetCore.csproj", "{33C50395-A4E5-4B94-8682-B844C31B6930}"
+EndProject
+Global
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		ODataFunctionSample.Models\ODataFunctionSample.Models.projitems*{1d794e9c-baa2-4e69-8268-1a879b020cb5}*SharedItemsImports = 4
+		ODataFunctionSample.Models\ODataFunctionSample.Models.projitems*{c4e021b8-16cd-4c82-90cd-7201a4ad6b00}*SharedItemsImports = 13
+	EndGlobalSection
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1D794E9C-BAA2-4E69-8268-1A879B020CB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D794E9C-BAA2-4E69-8268-1A879B020CB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D794E9C-BAA2-4E69-8268-1A879B020CB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D794E9C-BAA2-4E69-8268-1A879B020CB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33C50395-A4E5-4B94-8682-B844C31B6930}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33C50395-A4E5-4B94-8682-B844C31B6930}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33C50395-A4E5-4B94-8682-B844C31B6930}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33C50395-A4E5-4B94-8682-B844C31B6930}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F7A82C2A-86B3-4BD7-A15B-8B78645C1901}
+	EndGlobalSection
+EndGlobal

--- a/WebApi/v7.x/ODataFunctionSample/Readme.md
+++ b/WebApi/v7.x/ODataFunctionSample/Readme.md
@@ -1,0 +1,32 @@
+# ODataFunctionSample
+
+This sample solution is ported from [sample for WebApi 5.7](https://github.com/OData/ODataSamples/tree/master/WebApi/v4/ODataActionsSample) by upgrading service samples to use WebApi 7.0.1.
+
+Demonstrate service sample usage of handling Url functions, based on Microsoft.AspNet.OData (classic) and Microsoft.AspNetcore.OData.
+
+## Sample Function Call Url:
+```
+GET http://localhost:9010/odata/Products/Default.MostExpensive()
+GET http://localhost:9010/odata/Products/Default.Top10()
+GET http://localhost:9010/odata/Products(33)/Default.GetPriceRank()
+GET http://localhost:9010/odata/Products(33)/Default.CalculateGeneralSalesTax(state='WA')
+GET http://localhost:9010/odata/GetSalesTaxRate(state='CA')
+GET http://localhost:9010/odata/GetSalesTaxRate(state=@p1)?@p1='ND'
+```
+
+Use port 44363 for HTTPS. For example: 
+```
+https://localhost:44363/odata/Products/Default.MostExpensive()
+```
+
+
+## Sample Projects:
+Data is populated during service startup and maintained in memory.
+	
+- **WebApi classic sample: ODataFunctionSample.AspNet**:
+
+	Function calls are executed as part of startup. They can also be invoked interactively using REST client application (e.g. Postman) after service is up & running.
+
+- **WebApi AspNetCore sample: ODataFunctionsample.AspNetcore**:
+
+	Because this is a demo for function call urls, the web-app is a read-only service. After service is up & running, use REST client to interact with the service endpoints for the functions.


### PR DESCRIPTION
- Ported from [sample for WebApi 5.7](https://github.com/OData/ODataSamples/tree/master/WebApi/v4/ODataFunctionSample); upgrading service samples to use WebApi 7.0.1.

- Demonstrate Url function usage based on Microsoft.AspNet.OData (classic) and Microsoft.AspNetcore.OData.
