### PR TITLE
Add CORS support to WebAPI and RESTier Sample Trippin services

### DIFF
--- a/RESTier/TripPinInMemory/Microsoft.OData.Service.Sample.TrippinInMemory/App_Start/WebApiConfig.cs
+++ b/RESTier/TripPinInMemory/Microsoft.OData.Service.Sample.TrippinInMemory/App_Start/WebApiConfig.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Web.Http;
+using System.Web.Http.Cors;
 using System.Web.OData;
 using System.Web.OData.Extensions;
 using Microsoft.OData.Service.Sample.TrippinInMemory.Api;
@@ -18,6 +19,7 @@ namespace Microsoft.OData.Service.Sample.TrippinInMemory
             config.SetUseVerboseErrors(true);
             config.MessageHandlers.Add(new ETagMessageHandler());
             config.SetUrlKeyDelimiter(ODataUrlKeyDelimiter.Slash);
+            config.EnableCors(new EnableCorsAttribute("*", "*", "*"));
             RegisterTrippin(config, GlobalConfiguration.DefaultServer);
         }
 

--- a/RESTier/TripPinInMemory/Microsoft.OData.Service.Sample.TrippinInMemory/Microsoft.OData.Service.Sample.TrippinInMemory.csproj
+++ b/RESTier/TripPinInMemory/Microsoft.OData.Service.Sample.TrippinInMemory/Microsoft.OData.Service.Sample.TrippinInMemory.csproj
@@ -85,19 +85,23 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.Web.Cors, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Cors.5.2.7\lib\net45\System.Web.Cors.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Web.Http, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.7\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.Cors, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Cors.5.2.7\lib\net45\System.Web.Http.Cors.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>

--- a/RESTier/TripPinInMemory/Microsoft.OData.Service.Sample.TrippinInMemory/Web.config
+++ b/RESTier/TripPinInMemory/Microsoft.OData.Service.Sample.TrippinInMemory/Web.config
@@ -59,11 +59,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />

--- a/RESTier/TripPinInMemory/Microsoft.OData.Service.Sample.TrippinInMemory/packages.config
+++ b/RESTier/TripPinInMemory/Microsoft.OData.Service.Sample.TrippinInMemory/packages.config
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.AspNet.Cors" version="5.2.7" targetFramework="net452" />
   <package id="Microsoft.AspNet.OData" version="6.0.0-beta2" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.Cors" version="5.2.7" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" targetFramework="net45" />

--- a/RESTier/TripPinInMemory/Microsoft.Restier.Providers.InMemory/Microsoft.Restier.Providers.InMemory.csproj
+++ b/RESTier/TripPinInMemory/Microsoft.Restier.Providers.InMemory/Microsoft.Restier.Providers.InMemory.csproj
@@ -68,13 +68,12 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.2\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Http, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.2\lib\net45\System.Web.Http.dll</HintPath>
+    <Reference Include="System.Web.Http, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.7\lib\net45\System.Web.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Web.OData, Version=6.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -103,6 +102,7 @@
     <Compile Include="Utils\ODataSessionIdManager.cs" />
   </ItemGroup>
   <ItemGroup>
+
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Scenarios/TripPin/src/webapi/ODataSamples.WebApiService/App_Start/WebApiConfig.cs
+++ b/Scenarios/TripPin/src/webapi/ODataSamples.WebApiService/App_Start/WebApiConfig.cs
@@ -1,6 +1,7 @@
 ﻿namespace ODataSamples.WebApiService
 {
     using System.Web.Http;
+    using System.Web.Http.Cors;
     using System.Web.OData;
     using System.Web.OData.Batch;
     using System.Web.OData.Builder;
@@ -15,6 +16,7 @@
         {
             config.MessageHandlers.Add(new ETagMessageHandler());
             config.MapODataServiceRoute("odata", null, GetEdmModel(), new DefaultODataBatchHandler(GlobalConfiguration.DefaultServer));
+            config.EnableCors(new EnableCorsAttribute("*", "*", "*"));
             config.EnsureInitialized();
         }
 

--- a/Scenarios/TripPin/src/webapi/ODataSamples.WebApiService/ODataSamples.WebApiService.csproj
+++ b/Scenarios/TripPin/src/webapi/ODataSamples.WebApiService/ODataSamples.WebApiService.csproj
@@ -66,14 +66,18 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
-    <Reference Include="System.Web.Http, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.3\lib\net45\System.Web.Http.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Web.Cors, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.Cors.5.2.7\lib\net45\System.Web.Cors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.7\lib\net45\System.Web.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Web.Http.Cors, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Cors.5.2.7\lib\net45\System.Web.Http.Cors.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Http.WebHost, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.3\lib\net45\System.Web.Http.WebHost.dll</HintPath>

--- a/Scenarios/TripPin/src/webapi/ODataSamples.WebApiService/Web.config
+++ b/Scenarios/TripPin/src/webapi/ODataSamples.WebApiService/Web.config
@@ -43,11 +43,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Http" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.7.0" newVersion="5.2.7.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Scenarios/TripPin/src/webapi/ODataSamples.WebApiService/packages.config
+++ b/Scenarios/TripPin/src/webapi/ODataSamples.WebApiService/packages.config
@@ -1,8 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.AspNet.Cors" version="5.2.7" targetFramework="net45" />
   <package id="Microsoft.AspNet.OData" version="5.9.0" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Cors" version="5.2.7" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.OData.Core" version="6.15.0" targetFramework="net45" />
   <package id="Microsoft.OData.Edm" version="6.15.0" targetFramework="net45" />


### PR DESCRIPTION
Fixes https://github.com/OData/ODataSamples/issues/29
Support CORS against RESTier and WebAPI Trippin sample services.