### PR TITLE
Updated to new restier RC. Fixed registration order of Model builders.

### DIFF
--- a/RESTier/Trippin/Trippin/App_Start/WebApiConfig.cs
+++ b/RESTier/Trippin/Trippin/App_Start/WebApiConfig.cs
@@ -13,6 +13,7 @@ using Microsoft.Restier.Core.Model;
 using Microsoft.AspNet.OData.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Restier.Core;
+using Microsoft.Restier.AspNet;
 
 namespace Microsoft.OData.Service.Sample.Trippin
 {
@@ -33,8 +34,8 @@ namespace Microsoft.OData.Service.Sample.Trippin
                             MaxExpansionDepth = 3
                         }
                     );
-
                     services.AddSingleton<IChangeSetItemFilter, CustomizedSubmitProcessor>();
+                    services.AddRestierDefaultServices<TrippinApi>();
                     services.AddChainedService<IModelBuilder>((sp, next) => new TrippinApi.TrippinModelExtender(next));
                 }
             );

--- a/RESTier/Trippin/Trippin/Microsoft.OData.Service.Sample.Trippin.csproj
+++ b/RESTier/Trippin/Trippin/Microsoft.OData.Service.Sample.Trippin.csproj
@@ -112,13 +112,13 @@
       <HintPath>..\packages\Microsoft.OData.Edm.7.6.0\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Restier.AspNet, Version=1.0.0.0, Culture=neutral, PublicKeyToken=bd2d67c4036fede0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Restier.AspNet.1.0.0-CI-20191005-040300\lib\net472\Microsoft.Restier.AspNet.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Restier.AspNet.1.0.0-rc1.20191018.1\lib\net472\Microsoft.Restier.AspNet.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Restier.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=bd2d67c4036fede0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Restier.Core.1.0.0-CI-20191005-040300\lib\net462\Microsoft.Restier.Core.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Restier.Core.1.0.0-rc1.20191018.1\lib\net462\Microsoft.Restier.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Restier.EntityFramework, Version=1.0.0.0, Culture=neutral, PublicKeyToken=bd2d67c4036fede0, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Restier.EntityFramework.1.0.0-CI-20191005-040300\lib\net472\Microsoft.Restier.EntityFramework.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Restier.EntityFramework.1.0.0-CI-20190926-040246\lib\net472\Microsoft.Restier.EntityFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Spatial, Version=7.6.0.30605, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Spatial.7.6.0\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>

--- a/RESTier/Trippin/Trippin/packages.config
+++ b/RESTier/Trippin/Trippin/packages.config
@@ -11,9 +11,9 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net472" />
   <package id="Microsoft.OData.Core" version="7.6.0" targetFramework="net472" />
   <package id="Microsoft.OData.Edm" version="7.6.0" targetFramework="net472" />
-  <package id="Microsoft.Restier.AspNet" version="1.0.0-CI-20191005-040300" targetFramework="net472" />
-  <package id="Microsoft.Restier.Core" version="1.0.0-CI-20191005-040300" targetFramework="net472" />
-  <package id="Microsoft.Restier.EntityFramework" version="1.0.0-CI-20191005-040300" targetFramework="net472" />
+  <package id="Microsoft.Restier.AspNet" version="1.0.0-rc1.20191018.1" targetFramework="net472" />
+  <package id="Microsoft.Restier.Core" version="1.0.0-rc1.20191018.1" targetFramework="net472" />
+  <package id="Microsoft.Restier.EntityFramework" version="1.0.0-CI-20190926-040246" targetFramework="net472" />
   <package id="Microsoft.Spatial" version="7.6.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="System.Collections" version="4.0.11" targetFramework="net45" />


### PR DESCRIPTION
So the problem with the model builders was the order of registration. The delegate passed to UseRestier is executed after registration of the core Restier services, but before registration of the "default" services for a specific API.

To register your chaining service after registration of the default services, you have to call
```
services.AddRestierDefaultServices<TrippinApi>();
```
before registration of your chaining service. This way all default services are already in the container and you can chain on top of them. We will have to put this info in the docs.